### PR TITLE
Fix escaping.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function convertPhpToMoment(format) {
      *  Support escaped charaters. If the previous charater was a backslach just
      *  return the charater.
      */
-    if (format.charAt(i-1) === '\\') return char;
+    if (format.charAt(i-1) === '\\') return '[' + char + ']';
     return (typeof replacements[char] !== 'undefined') ? replacements[char] : char;
   }).join('');
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "devDependencies": {
     "eslint": "^3.13.1",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "moment": "^2.17.1"
   },
   "directories": {
     "test": "test"

--- a/test/test.js
+++ b/test/test.js
@@ -24,12 +24,12 @@ describe('phptomoment', function() {
       'F j, Y': 'January 20, 2017',
       'Y-m-d': '2017-01-20',
       'm/d/Y': '01/20/2017',
-      'Y/m/d \\a\\t g:i A': '2017/01/20 at 2:18 PM',
-      'g:i a \\\\ \\H\\e\\l\\l\\o': '2:18 pm \\ Hello',
+      'Y/m/d \\a\\t g:i A': '2017/01/20 at 8:18 PM',
+      'g:i a \\\\ \\H\\e\\l\\l\\o': '8:18 pm \\ Hello',
     };
 
     Object.keys(tests).map(function(obj) {
-      assert.equal(moment(testDate).format(phptomoment(obj)), tests[obj]);
+      assert.equal(moment.utc(testDate).format(phptomoment(obj)), tests[obj]);
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var phptomoment = require('../index.js');
+var moment = require('moment');
 describe('phptomoment', function() {
   it('should convert PHP date formats to Moment.js formats.', function() {
     var tests = {
@@ -8,13 +9,27 @@ describe('phptomoment', function() {
       'm/d/Y': 'MM/DD/YYYY',
       'd/m/Y': 'DD/MM/YYYY',
       'F j, Y g:i a': 'MMMM D, YYYY h:mm a',
-      'Y/m/d \\a\\t g:i A': 'YYYY/MM/DD at h:mm A',
-      'g:i a \\\\ \\H\\e\\l\\l\\o' : 'h:mm a \\ Hello', // Tricky one, show that formats can have backslashes.
+      'Y/m/d \\a\\t g:i A': 'YYYY/MM/DD [a][t] h:mm A',
+      'g:i a \\\\ \\H\\e\\l\\l\\o' : 'h:mm a [\\][ ][H][e][l][l][o]', // Tricky one, show that formats can have backslashes.
     };
 
     Object.keys(tests).map(function(obj) {
       assert.equal(phptomoment(obj), tests[obj]);
     });
+  });
 
+  it('should convert PHP date formats to Moment.js formats that work with Moment.js.', function() {
+    var testDate = '2017-01-20T20:18:08.679Z';
+    var tests = {
+      'F j, Y': 'January 20, 2017',
+      'Y-m-d': '2017-01-20',
+      'm/d/Y': '01/20/2017',
+      'Y/m/d \\a\\t g:i A': '2017/01/20 at 2:18 PM',
+      'g:i a \\\\ \\H\\e\\l\\l\\o': '2:18 pm \\ Hello',
+    };
+
+    Object.keys(tests).map(function(obj) {
+      assert.equal(moment(testDate).format(phptomoment(obj)), tests[obj]);
+    });
   });
 });


### PR DESCRIPTION
Moment escapes with [], like [at]. To fully support escaping, we need to add [] around any escaped characters. 